### PR TITLE
chore: Format with air

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,5 @@
 ^LICENSE\.md$
 ^_pkgdown\.yml$
 ^README\.Rmd$
+^[.]?air[.]toml$
+^\.vscode$

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "Posit.air-vscode"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "[r]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "Posit.air-vscode"
+  },
+  "[quarto]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "quarto.quarto"
+  }
+}

--- a/R/calf-cow.R
+++ b/R/calf-cow.R
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 #' Estimate Calf-Cow Ratio.
-#' 
+#'
 #'
 #' @param x A data frame that has recruitment data.
 #' @param adult_female_proportion Assumed or estimated proportion of females in the population
@@ -66,26 +66,34 @@
 #'   sex_ratio = 0.65,
 #'   variance = "bootstrap"
 #' )
-bbr_calf_cow_ratio <- function(x, adult_female_proportion = 0.65, sex_ratio = 0.5, variance = "bootstrap", year_start = 4L) {
+bbr_calf_cow_ratio <- function(
+  x,
+  adult_female_proportion = 0.65,
+  sex_ratio = 0.5,
+  variance = "bootstrap",
+  year_start = 4L
+) {
   x <- bboudata::bbd_chk_data_recruitment(x)
   chk::chk_range(adult_female_proportion)
   chk::chk_range(sex_ratio)
   chk::chk_string(variance)
   chk::chk_whole_number(year_start)
   chk::chk_range(year_start, c(1, 12))
-  
-  rec <- bbr_recruitment(x, 
-                         adult_female_proportion = adult_female_proportion, 
-                         sex_ratio = sex_ratio, 
-                         variance = variance,
-                         year_start = year_start)
-  
-  ccr <- 
-    rec |> 
+
+  rec <- bbr_recruitment(
+    x,
+    adult_female_proportion = adult_female_proportion,
+    sex_ratio = sex_ratio,
+    variance = variance,
+    year_start = year_start
+  )
+
+  ccr <-
+    rec |>
     dplyr::mutate(dplyr::across(c("estimate", "lower", "upper"), function(.x) {
       round(bbr_rec_to_cc(.x, sex_ratio = sex_ratio), 3)
     }))
-  
+
   # SE no longer valid - can't convert from recruitment
   ccr$se <- NULL
   tibble::as_tibble(ccr)

--- a/R/growth-summarize.R
+++ b/R/growth-summarize.R
@@ -44,14 +44,26 @@
 #' recruitment_est <- bbr_recruitment(bboudata::bbourecruit_a)
 #' survival_est <- bbr_survival(bboudata::bbousurv_a)
 #' growth_est <- bbr_growth(survival_est, recruitment_est)
-#' 
+#'
 #' bbr_growth_summarize(growth_est)
 #' }
 bbr_growth_summarize <- function(growth) {
-  chk::check_names(growth, c(
-    "PopulationName", "CaribouYear", "S", "R", "estimate", "se", "lower", "upper",
-    "prop_lgt1", "ran_r", "ran_s"
-  ))
+  chk::check_names(
+    growth,
+    c(
+      "PopulationName",
+      "CaribouYear",
+      "S",
+      "R",
+      "estimate",
+      "se",
+      "lower",
+      "upper",
+      "prop_lgt1",
+      "ran_r",
+      "ran_s"
+    )
+  )
 
   chk::check_data(
     growth,

--- a/R/growth.R
+++ b/R/growth.R
@@ -38,7 +38,7 @@
 #' \dontrun{
 #' recruitment_est <- bbr_recruitment(bboudata::bbourecruit_a)
 #' survival_est <- bbr_survival(bboudata::bbousurv_a)
-#' 
+#'
 #' growth_est <- bbr_growth(survival_est, recruitment_est)
 #' }
 bbr_growth <- function(survival, recruitment) {
@@ -126,7 +126,11 @@ bbr_growth <- function(survival, recruitment) {
       LGT1 = ifelse(.data$RanLambda > 1, 1, 0)
     ) |>
     dplyr::group_by(
-      .data$PopulationName, .data$CaribouYear, .data$S, .data$R, .data$estimate
+      .data$PopulationName,
+      .data$CaribouYear,
+      .data$S,
+      .data$R,
+      .data$estimate
     ) |>
     dplyr::summarize(
       se = sd(.data$RanLambda, na.rm = TRUE),

--- a/R/plot-growth-distributions.R
+++ b/R/plot-growth-distributions.R
@@ -31,7 +31,7 @@
 #' recruitment_est <- bbr_recruitment(bboudata::bbourecruit_a)
 #' survival_est <- bbr_survival(bboudata::bbousurv_a)
 #' growth_est <- bbr_growth(survival_est, recruitment_est)
-#' 
+#'
 #' bbr_plot_growth_distributions(growth_est)
 #' }
 bbr_plot_growth_distributions <- function(growth) {
@@ -50,8 +50,16 @@ bbr_plot_growth_distributions <- function(growth) {
   xmin <- quantile(LrawR$RanLambda, 0.0001)
   xmax <- quantile(LrawR$RanLambda, 0.99)
   # make sure that limits are still within range of lambda estimates for estimates with no CI's
-  xmax <- ifelse(xmax <= max(growth$estimate), max(growth$estimate) + 0.05, xmax)
-  xmin <- ifelse(xmin >= min(growth$estimate), min(growth$estimate) - 0.05, xmin)
+  xmax <- ifelse(
+    xmax <= max(growth$estimate),
+    max(growth$estimate) + 0.05,
+    xmax
+  )
+  xmin <- ifelse(
+    xmin >= min(growth$estimate),
+    min(growth$estimate) - 0.05,
+    xmin
+  )
 
   # subset data based on xlimits-this works better than using xlim or coord_cartesian in ggplot
   LrawR <- subset(LrawR, LrawR$RanLambda >= xmin & LrawR$RanLambda <= xmax)

--- a/R/plot-growth.R
+++ b/R/plot-growth.R
@@ -26,7 +26,7 @@
 #' recruitment_est <- bbr_recruitment(bboudata::bbourecruit_a)
 #' survival_est <- bbr_survival(bboudata::bbousurv_a)
 #' growth_est <- bbr_growth(survival_est, recruitment_est)
-#' 
+#'
 #' bbr_plot_growth(growth_est)
 #' }
 bbr_plot_growth <- function(growth) {

--- a/R/plot-recruitment.R
+++ b/R/plot-recruitment.R
@@ -24,7 +24,7 @@
 #' @examples
 #' \dontrun{
 #' recruitment_est <- bbr_recruitment(bboudata::bbourecruit_a)
-#' 
+#'
 #' bbr_plot_recruitment(recruitment_est)
 #' }
 bbr_plot_recruitment <- function(recruitment) {

--- a/R/plot-survival.R
+++ b/R/plot-survival.R
@@ -24,7 +24,7 @@
 #' @examples
 #' \dontrun{
 #' survival_est <- bbr_survival(bboudata::bbousurv_a)
-#' 
+#'
 #' bbr_plot_survival(survival_est)
 #' }
 bbr_plot_survival <- function(survival) {

--- a/R/rec-to-cc.R
+++ b/R/rec-to-cc.R
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 #' Recruitment to Calf Cow Ratio
-#' 
+#'
 #' Converts the female recruitment rate to the calf cow ratio.
 #' For further information see [bbr_cc_to_rec()].
 #'
 #' @param x A numeric vector of the recruitment rate
-#' @param sex_ratio A 
+#' @param sex_ratio A
 #'
 #' @return A numeric vector of the equivalent calf:cow ratio
 #' @seealso [bbr_cc_to_rec()]
@@ -31,23 +31,23 @@ bbr_rec_to_cc <- function(x, sex_ratio = 0.5) {
   chk_range(x)
   chk_number(sex_ratio)
   chk_range(sex_ratio)
-  
-  x2 <- - x / (x - 1)
+
+  x2 <- -x / (x - 1)
   x2 / sex_ratio
 }
 
 #' Calf Cow Ratio to Recruitment
-#' 
+#'
 #' The calf cow ratios is simply the number of calves divided by the number of cows.
-#' As described by DeCesare et al. (2012) in order to convert the 
-#' calf cow ratio to the female recruitment rate it is necessary to 
-#' multiple the calf cow ratio by the sex ratio to get the 
+#' As described by DeCesare et al. (2012) in order to convert the
+#' calf cow ratio to the female recruitment rate it is necessary to
+#' multiple the calf cow ratio by the sex ratio to get the
 #' female calf to cow ratio and then divide that number by itself plus 1 to
 #' get the female recruitment rate ie female calves divided by all females.
 #' To perform the inverse conversion see [bbr_rec_to_cc()]
 #'
 #' @param x A numeric vector of the calf:cow ratio
-#' @param sex_ratio A 
+#' @param sex_ratio A
 #'
 #' @return A numeric vector of the equivalent recruitment rate
 #' @seealso [bbr_rec_to_cc()]
@@ -59,8 +59,8 @@ bbr_cc_to_rec <- function(x, sex_ratio = 0.5) {
   chk_numeric(x)
   chk_range(x, c(0, 2))
   chk_number(sex_ratio)
-  chk_range(sex_ratio) 
-  
+  chk_range(sex_ratio)
+
   x2 <- x * sex_ratio
   x2 / (1 + x2)
 }

--- a/R/recruitment.R
+++ b/R/recruitment.R
@@ -73,7 +73,13 @@
 #'   sex_ratio = 0.65,
 #'   variance = "bootstrap"
 #' )
-bbr_recruitment <- function(x, adult_female_proportion = 0.65, sex_ratio = 0.5, variance = "bootstrap", year_start = 4L) {
+bbr_recruitment <- function(
+  x,
+  adult_female_proportion = 0.65,
+  sex_ratio = 0.5,
+  variance = "bootstrap",
+  year_start = 4L
+) {
   x <- bboudata::bbd_chk_data_recruitment(x)
   chk::chk_range(adult_female_proportion)
   chk::chk_range(sex_ratio)
@@ -84,7 +90,9 @@ bbr_recruitment <- function(x, adult_female_proportion = 0.65, sex_ratio = 0.5, 
   # Estimate total females based on adult_female_proportion and sex_ratio
   x <- dplyr::mutate(
     x,
-    females = .data$Cows + .data$UnknownAdults * adult_female_proportion + .data$Yearlings * sex_ratio,
+    females = .data$Cows +
+      .data$UnknownAdults * adult_female_proportion +
+      .data$Yearlings * sex_ratio,
     female_calves = .data$Calves * sex_ratio
   )
 
@@ -125,8 +133,16 @@ bbr_recruitment <- function(x, adult_female_proportion = 0.65, sex_ratio = 0.5, 
       logits = logit(.data$R),
       selogit = logit_se(.data$R_SE, .data$R)
     )
-    Compfull$R_CIU <- ilogit(wald_cl(Compfull$logits, Compfull$selogit, upper = TRUE))
-    Compfull$R_CIL <- ilogit(wald_cl(Compfull$logits, Compfull$selogit, upper = FALSE))
+    Compfull$R_CIU <- ilogit(wald_cl(
+      Compfull$logits,
+      Compfull$selogit,
+      upper = TRUE
+    ))
+    Compfull$R_CIL <- ilogit(wald_cl(
+      Compfull$logits,
+      Compfull$selogit,
+      upper = FALSE
+    ))
   }
 
   # bootstrap approach

--- a/R/survival.R
+++ b/R/survival.R
@@ -19,7 +19,7 @@
 #'
 #' @param x A data frame that has survival data.
 #' @param include_uncertain_morts A flag indicating whether to include uncertain mortalities in total mortalities.
-#'    The default value is TRUE. 
+#'    The default value is TRUE.
 #' @param variance Variance type to estimate. Can be the Greenwood estimator
 #'   `"greenwood"` or Cox Oakes estimator `"cox_oakes"`. The default is
 #'   "greenwood".
@@ -66,7 +66,12 @@
 #'   variance = "cox_oakes"
 #' )
 
-bbr_survival <- function(x, include_uncertain_morts = TRUE, variance = "greenwood", year_start = 4L) {
+bbr_survival <- function(
+  x,
+  include_uncertain_morts = TRUE,
+  variance = "greenwood",
+  year_start = 4L
+) {
   x <- bboudata::bbd_chk_data_survival(x)
   chk::chk_flag(include_uncertain_morts)
   chk::chk_string(variance)
@@ -76,12 +81,13 @@ bbr_survival <- function(x, include_uncertain_morts = TRUE, variance = "greenwoo
   # make sure data set is sorted properly
   x <- dplyr::arrange(x, .data$Year, .data$Month)
   # Tally total mortalities.
-  
-  ifelse(include_uncertain_morts, 
-  x$Morts <- x$MortalitiesCertain + x$MortalitiesUncertain,
-  x$Morts <- x$MortalitiesCertain
+
+  ifelse(
+    include_uncertain_morts,
+    x$Morts <- x$MortalitiesCertain + x$MortalitiesUncertain,
+    x$Morts <- x$MortalitiesCertain
   )
-  
+
   # Months with 0 collars monitored are removed but this is noted to user later
   # and estimates scaled appropriately
   x <- subset(x, x$StartTotal > 0)
@@ -93,7 +99,8 @@ bbr_survival <- function(x, include_uncertain_morts = TRUE, variance = "greenwoo
   LiveDeadCount <- dplyr::mutate(
     x,
     Smonth = (1 - (.data$Morts / .data$StartTotal)),
-    Smonth_varj = .data$Morts / (.data$StartTotal * (.data$StartTotal - .data$Morts))
+    Smonth_varj = .data$Morts /
+      (.data$StartTotal * (.data$StartTotal - .data$Morts))
   )
 
   YearSurv <-
@@ -117,7 +124,8 @@ bbr_survival <- function(x, include_uncertain_morts = TRUE, variance = "greenwoo
   # Variance estimate using the Greenwood formula for variance
   YearSurv$S_Var_Green <- YearSurv$S^2 * YearSurv$S_var1
   # Variance estimate using the Pollock et al 1989 method
-  YearSurv$S_Var_Pollock <- (YearSurv$S^2 * (1 - YearSurv$S)) / YearSurv$sum_alive
+  YearSurv$S_Var_Pollock <- (YearSurv$S^2 * (1 - YearSurv$S)) /
+    YearSurv$sum_alive
   YearSurv$S_Var <- ifelse(
     YearSurv$VarType == "cox_oakes",
     YearSurv$S_Var_Pollock,
@@ -136,21 +144,21 @@ bbr_survival <- function(x, include_uncertain_morts = TRUE, variance = "greenwoo
     "No Mortalities all year (SE=0)",
     NA_character_
   )
-  
+
   YearSurv$status <- ifelse(
-    is.na(YearSurv$Status1) & is.na(YearSurv$Status2), 
+    is.na(YearSurv$Status1) & is.na(YearSurv$Status2),
     NA_character_,
     ifelse(
       !is.na(YearSurv$Status1) & !is.na(YearSurv$Status2),
       paste(YearSurv$Status1, YearSurv$Status2, sep = "; "),
       ifelse(
-        !is.na(YearSurv$Status1), 
-        YearSurv$Status1, 
+        !is.na(YearSurv$Status1),
+        YearSurv$Status1,
         YearSurv$Status2
       )
     )
   )
-  
+
   # scale estimates to a year if less than 12 months monitored
   YearSurv$S <- YearSurv$S^(12 / YearSurv$monthcount)
   YearSurv$S_Var <- YearSurv$S_Var^(12 / YearSurv$monthcount)
@@ -162,8 +170,16 @@ bbr_survival <- function(x, include_uncertain_morts = TRUE, variance = "greenwoo
     logits = logit(.data$S),
     selogit = logit_se(.data$S_SE, .data$S)
   )
-  YearSurv$S_CIU <- ilogit(wald_cl(YearSurv$logits, YearSurv$selogit, upper = TRUE))
-  YearSurv$S_CIL <- ilogit(wald_cl(YearSurv$logits, YearSurv$selogit, upper = FALSE))
+  YearSurv$S_CIU <- ilogit(wald_cl(
+    YearSurv$logits,
+    YearSurv$selogit,
+    upper = TRUE
+  ))
+  YearSurv$S_CIL <- ilogit(wald_cl(
+    YearSurv$logits,
+    YearSurv$selogit,
+    upper = FALSE
+  ))
 
   # round estimates for table.
   YearSurv$mean_monitored <- round(YearSurv$meanalive, 1)

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,7 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = true
+default-exclude = true

--- a/scripts/build.R
+++ b/scripts/build.R
@@ -13,7 +13,10 @@
 # limitations under the License.
 
 roxygen2md::roxygen2md()
-styler::style_pkg(filetype = c("R", "Rmd"))
+
+system2("air", c("format", "."))
+styler::style_pkg(filetype = c("Rmd")) # Air currently doesn't format .Rmd files
+
 lintr::lint_package(
   linters = lintr::linters_with_defaults(
     line_length_linter = lintr::line_length_linter(400)

--- a/tests/testthat/test-calfcow.R
+++ b/tests/testthat/test-calfcow.R
@@ -19,21 +19,28 @@ test_that("recruitment a works", {
         bbr_calf_cow_ratio(
           bboudata::bbourecruit_a
         ),
-        n = 100, width = 100
+        n = 100,
+        width = 100
       )
       print(
         bbr_calf_cow_ratio(
           bboudata::bbourecruit_a,
-          adult_female_proportion = 0.2, sex_ratio = 0.6, variance = "binomial"
+          adult_female_proportion = 0.2,
+          sex_ratio = 0.6,
+          variance = "binomial"
         ),
-        n = 100, width = 100
+        n = 100,
+        width = 100
       )
       print(
         bbr_calf_cow_ratio(
           bboudata::bbourecruit_a,
-          adult_female_proportion = 0.2, sex_ratio = 0.5, variance = "bootstrap"
+          adult_female_proportion = 0.2,
+          sex_ratio = 0.5,
+          variance = "bootstrap"
         ),
-        n = 100, width = 100
+        n = 100,
+        width = 100
       )
     })
   })
@@ -46,21 +53,28 @@ test_that("recruitment b works", {
         bbr_calf_cow_ratio(
           bboudata::bbourecruit_b
         ),
-        n = 100, width = 100
+        n = 100,
+        width = 100
       )
       print(
         bbr_calf_cow_ratio(
           bboudata::bbourecruit_b,
-          adult_female_proportion = 0.65, sex_ratio = 0.6, variance = "binomial"
+          adult_female_proportion = 0.65,
+          sex_ratio = 0.6,
+          variance = "binomial"
         ),
-        n = 100, width = 100
+        n = 100,
+        width = 100
       )
       print(
         bbr_calf_cow_ratio(
           bboudata::bbourecruit_b,
-          adult_female_proportion = 0.2, sex_ratio = 0.5, variance = "bootstrap"
+          adult_female_proportion = 0.2,
+          sex_ratio = 0.5,
+          variance = "bootstrap"
         ),
-        n = 100, width = 100
+        n = 100,
+        width = 100
       )
     })
   })
@@ -72,21 +86,28 @@ test_that("recruitment c works", {
   expect_snapshot({
     print(
       bbr_calf_cow_ratio(bboudata::bbourecruit_c),
-      n = 100, width = 100
+      n = 100,
+      width = 100
     )
     print(
       bbr_calf_cow_ratio(
         bboudata::bbourecruit_c,
-        adult_female_proportion = 0.65, sex_ratio = 0.6, variance = "binomial"
+        adult_female_proportion = 0.65,
+        sex_ratio = 0.6,
+        variance = "binomial"
       ),
-      n = 100, width = 100
+      n = 100,
+      width = 100
     )
     print(
       bbr_calf_cow_ratio(
         bboudata::bbourecruit_c,
-        adult_female_proportion = 0.2, sex_ratio = 0.5, variance = "bootstrap"
+        adult_female_proportion = 0.2,
+        sex_ratio = 0.5,
+        variance = "bootstrap"
       ),
-      n = 100, width = 100
+      n = 100,
+      width = 100
     )
   })
 })

--- a/tests/testthat/test-growth.R
+++ b/tests/testthat/test-growth.R
@@ -30,7 +30,8 @@ test_that("pop a works", {
     output <-
       data.frame(
         round_df_sigs(
-          bbr_growth(survival_est, recruitment_est), 3
+          bbr_growth(survival_est, recruitment_est),
+          3
         )
       )
 
@@ -66,7 +67,8 @@ test_that("pop b works", {
     output <-
       data.frame(
         round_df_sigs(
-          bbr_growth(survival_est, recruitment_est), 3
+          bbr_growth(survival_est, recruitment_est),
+          3
         )
       )
 
@@ -102,7 +104,8 @@ test_that("pop c works", {
     output <-
       data.frame(
         round_df_sigs(
-          bbr_growth(survival_est, recruitment_est), 3
+          bbr_growth(survival_est, recruitment_est),
+          3
         )
       )
 
@@ -145,7 +148,9 @@ test_that("test data works", {
       sum_dead = c(3L, 3L, 3L, 0L),
       sum_alive = c(39L, 149L, 179L, 242L),
       status = c(
-        "Only 9 months monitored - ", " - ", " - ",
+        "Only 9 months monitored - ",
+        " - ",
+        " - ",
         " - No Mortalities all year (SE=0)"
       )
     )
@@ -153,7 +158,8 @@ test_that("test data works", {
     output <-
       data.frame(
         round_df_sigs(
-          bbr_growth(survival_est, recruitment_est), 3
+          bbr_growth(survival_est, recruitment_est),
+          3
         )
       )
 
@@ -196,7 +202,9 @@ test_that("errors if no populations overlap", {
       sum_dead = c(3L, 3L, 3L, 0L),
       sum_alive = c(39L, 149L, 179L, 242L),
       status = c(
-        "Only 9 months monitored - ", " - ", " - ",
+        "Only 9 months monitored - ",
+        " - ",
+        " - ",
         " - No Mortalities all year (SE=0)"
       )
     )
@@ -233,7 +241,9 @@ test_that("errors if no years overlap", {
       sum_dead = c(3L, 3L, 3L, 0L),
       sum_alive = c(39L, 149L, 179L, 242L),
       status = c(
-        "Only 9 months monitored - ", " - ", " - ",
+        "Only 9 months monitored - ",
+        " - ",
+        " - ",
         " - No Mortalities all year (SE=0)"
       )
     )
@@ -314,7 +324,9 @@ test_that("NA instead in dataset work", {
       sum_dead = c(3L, 3L, 3L, 0L),
       sum_alive = c(39L, 149L, 179L, 242L),
       status = c(
-        "Only 9 months monitored - ", " - ", " - ",
+        "Only 9 months monitored - ",
+        " - ",
+        " - ",
         " - No Mortalities all year (SE=0)"
       )
     )
@@ -322,7 +334,8 @@ test_that("NA instead in dataset work", {
     output <-
       data.frame(
         round_df_sigs(
-          bbr_growth(survival_est, recruitment_est), 3
+          bbr_growth(survival_est, recruitment_est),
+          3
         )
       )
 

--- a/tests/testthat/test-plot-growth-distributions.R
+++ b/tests/testthat/test-plot-growth-distributions.R
@@ -106,7 +106,9 @@ test_that("errors when more then 1 pop in data set", {
       sum_dead = c(3L, 3L, 3L, 0L),
       sum_alive = c(39L, 149L, 179L, 242L),
       status = c(
-        "Only 9 months monitored - ", " - ", " - ",
+        "Only 9 months monitored - ",
+        " - ",
+        " - ",
         " - No Mortalities all year (SE=0)"
       )
     )

--- a/tests/testthat/test-plot-recruitment.R
+++ b/tests/testthat/test-plot-recruitment.R
@@ -18,7 +18,8 @@ test_that("pop a works", {
       bboudata::bbourecruit_a,
       adult_female_proportion = 0.65,
       sex_ratio = 0.5,
-      variance = "binomial", year_start = 1L
+      variance = "binomial",
+      year_start = 1L
     )
 
     plot <- bbr_plot_recruitment(recruitment_est)

--- a/tests/testthat/test-plot-survival.R
+++ b/tests/testthat/test-plot-survival.R
@@ -69,7 +69,12 @@ test_that("skip x ticks when more then 6 groups", {
     sum_dead = c(3L, 3L, 3L, 0L, 7L, 2L, 4L),
     sum_alive = c(39L, 149L, 179L, 242L, 251L, 124L, 365L),
     status = c(
-      "Only 9 months monitored - ", " - ", " - ", " - ", " - ", " - ",
+      "Only 9 months monitored - ",
+      " - ",
+      " - ",
+      " - ",
+      " - ",
+      " - ",
       " - "
     )
   )
@@ -98,7 +103,9 @@ test_that("errors if no year column", {
     sum_dead = c(3L, 3L, 3L, 0L),
     sum_alive = c(39L, 149L, 179L, 242L),
     status = c(
-      "Only 9 months monitored - ", " - ", " - ",
+      "Only 9 months monitored - ",
+      " - ",
+      " - ",
       " - No Mortalities all year (SE=0)"
     )
   )

--- a/tests/testthat/test-rec-to-cc.R
+++ b/tests/testthat/test-rec-to-cc.R
@@ -5,9 +5,12 @@ test_that("bbr_rec_to_cc works", {
   expect_identical(bbr_rec_to_cc(0.5), 2)
   expect_identical(bbr_rec_to_cc(0.5, sex_ratio = 1), 1)
   x <- c(0.25, 0.5, NA)
-  expect_equal(bbr_rec_to_cc(x), c(2/3, 2, NA))
-  expect_equal(bbr_cc_to_rec(bbr_rec_to_cc(x)),  x)
-  expect_equal(bbr_cc_to_rec(bbr_rec_to_cc(x, sex_ratio = 0.7), sex_ratio = 0.7),  x)
+  expect_equal(bbr_rec_to_cc(x), c(2 / 3, 2, NA))
+  expect_equal(bbr_cc_to_rec(bbr_rec_to_cc(x)), x)
+  expect_equal(
+    bbr_cc_to_rec(bbr_rec_to_cc(x, sex_ratio = 0.7), sex_ratio = 0.7),
+    x
+  )
 })
 
 
@@ -16,9 +19,12 @@ test_that("bbr_cc_to_rec works", {
   expect_identical(bbr_cc_to_rec(NA_real_), NA_real_)
   expect_identical(bbr_cc_to_rec(0), 0)
   expect_identical(bbr_cc_to_rec(0.5), 0.2)
-  expect_identical(bbr_cc_to_rec(0.5, sex_ratio = 1), 1/3)
+  expect_identical(bbr_cc_to_rec(0.5, sex_ratio = 1), 1 / 3)
   x <- c(0.25, 0.5, NA)
-  expect_equal(bbr_cc_to_rec(x), c(1/9, 1/5, NA))
-  expect_equal(bbr_rec_to_cc(bbr_cc_to_rec(x)),  x)
-  expect_equal(bbr_rec_to_cc(bbr_cc_to_rec(x, sex_ratio = 0.7), sex_ratio = 0.7),  x)
+  expect_equal(bbr_cc_to_rec(x), c(1 / 9, 1 / 5, NA))
+  expect_equal(bbr_rec_to_cc(bbr_cc_to_rec(x)), x)
+  expect_equal(
+    bbr_rec_to_cc(bbr_cc_to_rec(x, sex_ratio = 0.7), sex_ratio = 0.7),
+    x
+  )
 })

--- a/tests/testthat/test-recruitment.R
+++ b/tests/testthat/test-recruitment.R
@@ -19,21 +19,28 @@ test_that("recruitment a works", {
         bbr_recruitment(
           bboudata::bbourecruit_a
         ),
-        n = 100, width = 100
+        n = 100,
+        width = 100
       )
       print(
         bbr_recruitment(
           bboudata::bbourecruit_a,
-          adult_female_proportion = 0.2, sex_ratio = 0.6, variance = "binomial"
+          adult_female_proportion = 0.2,
+          sex_ratio = 0.6,
+          variance = "binomial"
         ),
-        n = 100, width = 100
+        n = 100,
+        width = 100
       )
       print(
         bbr_recruitment(
           bboudata::bbourecruit_a,
-          adult_female_proportion = 0.2, sex_ratio = 0.5, variance = "bootstrap"
+          adult_female_proportion = 0.2,
+          sex_ratio = 0.5,
+          variance = "bootstrap"
         ),
-        n = 100, width = 100
+        n = 100,
+        width = 100
       )
     })
   })
@@ -46,21 +53,28 @@ test_that("recruitment b works", {
         bbr_recruitment(
           bboudata::bbourecruit_b
         ),
-        n = 100, width = 100
+        n = 100,
+        width = 100
       )
       print(
         bbr_recruitment(
           bboudata::bbourecruit_b,
-          adult_female_proportion = 0.65, sex_ratio = 0.6, variance = "binomial"
+          adult_female_proportion = 0.65,
+          sex_ratio = 0.6,
+          variance = "binomial"
         ),
-        n = 100, width = 100
+        n = 100,
+        width = 100
       )
       print(
         bbr_recruitment(
           bboudata::bbourecruit_b,
-          adult_female_proportion = 0.2, sex_ratio = 0.5, variance = "bootstrap"
+          adult_female_proportion = 0.2,
+          sex_ratio = 0.5,
+          variance = "bootstrap"
         ),
-        n = 100, width = 100
+        n = 100,
+        width = 100
       )
     })
   })
@@ -72,21 +86,28 @@ test_that("recruitment c works", {
   expect_snapshot({
     print(
       bbr_recruitment(bboudata::bbourecruit_c),
-      n = 100, width = 100
+      n = 100,
+      width = 100
     )
     print(
       bbr_recruitment(
         bboudata::bbourecruit_c,
-        adult_female_proportion = 0.65, sex_ratio = 0.6, variance = "binomial"
+        adult_female_proportion = 0.65,
+        sex_ratio = 0.6,
+        variance = "binomial"
       ),
-      n = 100, width = 100
+      n = 100,
+      width = 100
     )
     print(
       bbr_recruitment(
         bboudata::bbourecruit_c,
-        adult_female_proportion = 0.2, sex_ratio = 0.5, variance = "bootstrap"
+        adult_female_proportion = 0.2,
+        sex_ratio = 0.5,
+        variance = "bootstrap"
       ),
-      n = 100, width = 100
+      n = 100,
+      width = 100
     )
   })
 })

--- a/tests/testthat/test-survival.R
+++ b/tests/testthat/test-survival.R
@@ -17,30 +17,38 @@ test_that("survival a works", {
     print(
       bbr_survival(
         bboudata::bbousurv_a,
-        include_uncertain_morts = TRUE, variance = "cox_oakes"
+        include_uncertain_morts = TRUE,
+        variance = "cox_oakes"
       ),
-      n = 100, width = 100
+      n = 100,
+      width = 100
     )
     print(
       bbr_survival(
         bboudata::bbousurv_a,
-        include_uncertain_morts = FALSE, variance = "cox_oakes"
+        include_uncertain_morts = FALSE,
+        variance = "cox_oakes"
       ),
-      n = 100, width = 100
+      n = 100,
+      width = 100
     )
     print(
       bbr_survival(
         bboudata::bbousurv_a,
-        include_uncertain_morts = TRUE, variance = "greenwood"
+        include_uncertain_morts = TRUE,
+        variance = "greenwood"
       ),
-      n = 100, width = 100
+      n = 100,
+      width = 100
     )
     print(
       bbr_survival(
         bboudata::bbousurv_a,
-        include_uncertain_morts = FALSE, variance = "greenwood"
+        include_uncertain_morts = FALSE,
+        variance = "greenwood"
       ),
-      n = 100, width = 100
+      n = 100,
+      width = 100
     )
   })
 })
@@ -50,30 +58,38 @@ test_that("survival b works", {
     print(
       bbr_survival(
         bboudata::bbousurv_b,
-        include_uncertain_morts = TRUE, variance = "cox_oakes"
+        include_uncertain_morts = TRUE,
+        variance = "cox_oakes"
       ),
-      n = 100, width = 100
+      n = 100,
+      width = 100
     )
     print(
       bbr_survival(
         bboudata::bbousurv_b,
-        include_uncertain_morts = FALSE, variance = "cox_oakes"
+        include_uncertain_morts = FALSE,
+        variance = "cox_oakes"
       ),
-      n = 100, width = 100
+      n = 100,
+      width = 100
     )
     print(
       bbr_survival(
         bboudata::bbousurv_b,
-        include_uncertain_morts = TRUE, variance = "greenwood"
+        include_uncertain_morts = TRUE,
+        variance = "greenwood"
       ),
-      n = 100, width = 100
+      n = 100,
+      width = 100
     )
     print(
       bbr_survival(
         bboudata::bbousurv_b,
-        include_uncertain_morts = FALSE, variance = "greenwood"
+        include_uncertain_morts = FALSE,
+        variance = "greenwood"
       ),
-      n = 100, width = 100
+      n = 100,
+      width = 100
     )
   })
 })
@@ -83,30 +99,38 @@ test_that("survival c works", {
     print(
       bbr_survival(
         bboudata::bbousurv_c,
-        include_uncertain_morts = TRUE, variance = "cox_oakes"
+        include_uncertain_morts = TRUE,
+        variance = "cox_oakes"
       ),
-      n = 100, width = 100
+      n = 100,
+      width = 100
     )
     print(
       bbr_survival(
         bboudata::bbousurv_c,
-        include_uncertain_morts = FALSE, variance = "cox_oakes"
+        include_uncertain_morts = FALSE,
+        variance = "cox_oakes"
       ),
-      n = 100, width = 100
+      n = 100,
+      width = 100
     )
     print(
       bbr_survival(
         bboudata::bbousurv_c,
-        include_uncertain_morts = TRUE, variance = "greenwood"
+        include_uncertain_morts = TRUE,
+        variance = "greenwood"
       ),
-      n = 100, width = 100
+      n = 100,
+      width = 100
     )
     print(
       bbr_survival(
         bboudata::bbousurv_c,
-        include_uncertain_morts = FALSE, variance = "greenwood"
+        include_uncertain_morts = FALSE,
+        variance = "greenwood"
       ),
-      n = 100, width = 100
+      n = 100,
+      width = 100
     )
   })
 })


### PR DESCRIPTION
Closes #63

Adds air formatting following the org standard (as in `chk`):

- `air.toml` with the standard `[format]` settings
- `.vscode/` settings recommending and enabling format-on-save with Posit air
- `.Rbuildignore` entries for `air.toml` and `.vscode`
- All R source formatted with `air format .` (air 0.9.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)